### PR TITLE
Wrapping CUDA and cuBLAS calls with EL_CHECK_CUDA macro

### DIFF
--- a/include/El/blas_like/level1/Zero.hpp
+++ b/include/El/blas_like/level1/Zero.hpp
@@ -42,8 +42,7 @@ void Zero( AbstractMatrix<T>& A )
             break;
 #ifdef HYDROGEN_HAVE_CUDA
         case Device::GPU:
-            if (cudaMemset(ABuf,0x0,height*width*sizeof(T)) != cudaSuccess)
-                RuntimeError("Something wrong with cudaMemset");
+            EL_CHECK_CUDA(cudaMemset(ABuf,0x0,height*width*sizeof(T)));
             break;
 #endif // HYDROGEN_HAVE_CUDA
         default:
@@ -62,8 +61,7 @@ void Zero( AbstractMatrix<T>& A )
                 break;
 #ifdef HYDROGEN_HAVE_CUDA
             case Device::GPU:
-                if (cudaMemset(ABuf+j*ALDim,0x0,height*sizeof(T)) != cudaSuccess)
-                    RuntimeError("Something wrong with cudaMemset");
+                EL_CHECK_CUDA(cudaMemset(ABuf+j*ALDim,0x0,height*sizeof(T)));
                 break;
 #endif // HYDROGEN_HAVE_CUDA
             default:

--- a/include/El/core/imports/cuda.hpp
+++ b/include/El/core/imports/cuda.hpp
@@ -25,7 +25,7 @@ struct CudaError : std::runtime_error
     {}
 };// struct CudaError
 
-#define FORCE_CHECK_CUDA(cuda_call)                                     \
+#define EL_FORCE_CHECK_CUDA(cuda_call)                                  \
     do                                                                  \
     {                                                                   \
         const cudaError_t cuda_status = cuda_call;                      \
@@ -37,12 +37,21 @@ struct CudaError : std::runtime_error
     } while (0)
 
 #ifdef EL_RELEASE
-#define CHECK_CUDA(cuda_call) cuda_call
-#define CHECK_CUDNN(cudnn_call) cudnn_call
+#define EL_CHECK_CUDA(cuda_call) cuda_call
+#define EL_CHECK_CUDNN(cudnn_call) cudnn_call
 #else
-#define CHECK_CUDA(cuda_call) FORCE_CHECK_CUDA(cuda_call)
-#define CHECK_CUDNN(cudnn_call) FORCE_CHECK_CUDNN(cudnn_call)
+#define EL_CHECK_CUDA(cuda_call)                   \
+  do {                                             \
+    EL_FORCE_CHECK_CUDA(cuda_call);                \
+    EL_FORCE_CHECK_CUDA(cudaDeviceSynchronize());  \
+  } while (0)
+#define EL_CHECK_CUDNN(cudnn_call)                \
+  do {                                            \
+    EL_FORCE_CHECK_CUDNN(cudnn_call);             \
+    EL_FORCE_CHECK_CUDA(cudaDeviceSynchronize()); \
+  } while (0)
 #endif // #ifdef LBANN_DEBUG
+
 
 void InitializeCUDA(int,char*[]);
 

--- a/src/blas_like/level1/GPU/Transpose.cu
+++ b/src/blas_like/level1/GPU/Transpose.cu
@@ -63,7 +63,6 @@ void Transpose_GPU_impl(
     dim3 threads{BLOCK_DIM,BLOCK_DIM,1};
     transpose_kernel<<<grid,threads>>>(
         dest, dest_ldim, src, height, width, ldim);
-    cudaThreadSynchronize(); // FIXME Sync here or...??
 }
 
 template void Transpose_GPU_impl(

--- a/src/blas_like/level3/Gemm/NN.hpp
+++ b/src/blas_like/level3/Gemm/NN.hpp
@@ -449,8 +449,6 @@ void SUMMA_NN
         {
             // FIXME (trb 03/27/18): There's a correctness issue with
             // this method. This exception is for your own safety.
-            RuntimeError("GEMM_DEFAULT selected NNDot.");
-
             SUMMA_NNDot(alpha, A, B, C, blockSizeDot);
         }
         else if (m <= n && weightTowardsC*m <= sumDim)

--- a/src/core/imports/cublas.cpp
+++ b/src/core/imports/cublas.cpp
@@ -1,4 +1,5 @@
 #include "El-lite.hpp"
+#include "El/core/imports/cuda.hpp"
 #include "El/core/imports/cublas.hpp"
 
 #include <cublas_v2.h>
@@ -75,22 +76,16 @@ cuBLAS_Manager manager_;
               ScalarType const* X, int incx,            \
               ScalarType* Y, int incy)                  \
     {                                                   \
-        auto ret = cublas ## TypeChar ## axpy(          \
-            manager_, n, &alpha, X, incx, Y, incy);     \
-        if (ret != CUBLAS_STATUS_SUCCESS)               \
-            RuntimeError("cuBLAS::Axpy failed!");       \
-        cudaThreadSynchronize(); /* FIXME */            \
+      EL_CHECK_CUDA(cublas ## TypeChar ## axpy(         \
+            manager_, n, &alpha, X, incx, Y, incy));    \
     }
 
 #define ADD_COPY_IMPL(ScalarType, TypeChar)             \
     void Copy(int n, ScalarType const* X, int incx,     \
               ScalarType* Y, int incy)                  \
     {                                                   \
-        auto ret = cublas ## TypeChar ## copy(          \
-            manager_, n, X, incx, Y, incy);             \
-        if (ret != CUBLAS_STATUS_SUCCESS)               \
-            RuntimeError("cuBLAS::Axpy failed!");       \
-        cudaThreadSynchronize(); /* FIXME */            \
+      EL_CHECK_CUDA(cublas ## TypeChar ## copy(         \
+            manager_, n, X, incx, Y, incy));            \
     }
 
 //
@@ -105,13 +100,10 @@ cuBLAS_Manager manager_;
         ScalarType const& beta,                                         \
         ScalarType* C, int CLDim )                                      \
     {                                                                   \
-        auto ret = cublas ## TypeChar ## gemv(                          \
+      EL_CHECK_CUDA(cublas ## TypeChar ## gemv(                         \
             manager_,                                                   \
             CharTocuBLASOp(transA),                                     \
-            m, n, &alpha, A, ALDim, B, BLDim, &beta, C, CLDim);         \
-        if (ret != CUBLAS_STATUS_SUCCESS)                               \
-            RuntimeError("cuBLAS::Gemv failed!");                       \
-        cudaThreadSynchronize();/* FIXME */                             \
+            m, n, &alpha, A, ALDim, B, BLDim, &beta, C, CLDim));        \
     }
 
 //
@@ -126,13 +118,10 @@ cuBLAS_Manager manager_;
         ScalarType const& beta,                                         \
         ScalarType* C, int CLDim )                                      \
     {                                                                   \
-        auto ret = cublas ## TypeChar ## gemm(                          \
+      EL_CHECK_CUDA(cublas ## TypeChar ## gemm(                         \
             manager_,                                                   \
             CharTocuBLASOp(transA), CharTocuBLASOp(transB),             \
-            m, n, k, &alpha, A, ALDim, B, BLDim, &beta, C, CLDim);      \
-        if (ret != CUBLAS_STATUS_SUCCESS)                               \
-            RuntimeError("cuBLAS::Gemm failed!");                       \
-        cudaThreadSynchronize();/* FIXME */                             \
+            m, n, k, &alpha, A, ALDim, B, BLDim, &beta, C, CLDim));     \
     }
 
 // BLAS 1


### PR DESCRIPTION
Removing the conservative cudaThreadSynchronization calls that followed most CUDA calls.  Now using the EL_CHECK_CUDA macro to check for error conditions and synchronize in debug builds.