### PR TITLE
Fixed the initialization of CUDA with respect to MPI 

### DIFF
--- a/include/El/core/imports/cuda.hpp
+++ b/include/El/core/imports/cuda.hpp
@@ -53,7 +53,7 @@ struct CudaError : std::runtime_error
 #endif // #ifdef LBANN_DEBUG
 
 
-void InitializeCUDA(int,char*[]);
+void InitializeCUDA(int,char*[],int requested_device_id = -1);
 
 }// namespace El
 

--- a/src/core/environment.cpp
+++ b/src/core/environment.cpp
@@ -139,6 +139,10 @@ void Initialize( int& argc, char**& argv )
 
     ::args = new Args( argc, argv );
 
+#ifdef HYDROGEN_HAVE_CUDA
+    InitializeCUDA(argc,argv,0);
+#endif
+
     ::numElemInits = 1;
     if( !mpi::Initialized() )
     {
@@ -173,10 +177,6 @@ void Initialize( int& argc, char**& argv )
         }
 #endif
     }
-
-#ifdef HYDROGEN_HAVE_CUDA
-    InitializeCUDA(argc,argv);
-#endif
 
 #ifdef EL_HAVE_QT5
     InitializeQt5( argc, argv );

--- a/src/core/imports/cublas.cpp
+++ b/src/core/imports/cublas.cpp
@@ -141,7 +141,7 @@ ADD_GEMM_IMPL(double, D)
 
 }// namespace cublas
 
-void InitializeCUDA(int,char*[])
+void InitializeCUDA(int,char*[], int requested_device_id)
 {
     int device_count;
     auto error = cudaGetDeviceCount(&device_count);
@@ -152,7 +152,10 @@ void InitializeCUDA(int,char*[])
     if (device_count < 1)
         RuntimeError("No CUDA devices found!");
 
-    int device_id = 0;
+    int device_id = requested_device_id;
+    if(requested_device_id < 0) {
+      device_id = 0;
+    }
 
     cudaDeviceProp deviceProp;
     error = cudaGetDeviceProperties(&deviceProp, device_id);
@@ -161,9 +164,10 @@ void InitializeCUDA(int,char*[])
         RuntimeError("CUDA initialize error: ", cudaGetErrorString(error));
 
     if (deviceProp.computeMode == cudaComputeModeProhibited)
-        RuntimeError("Device 0 is in ComputeModeProhibited mode. Can't use.");
+        RuntimeError(std::string {} + "Device " + std::to_string(device_id)
+                     + " is in ComputeModeProhibited mode. Can't use.");
 
-    cudaSetDevice(0);
+    cudaSetDevice(device_id);
 }
 
 }// namespace El


### PR DESCRIPTION
This PR makes sure that the GPU device id is set prior to initializing the MPI library.  
According to a note at: https://devblogs.nvidia.com/benchmarking-cuda-aware-mpi/
this is necessary to make sure that MPI chooses the same GPU as the application code.  
I also added a parameter to the initialization to pass in a CUDA device id.