### PR TITLE
Miscellaneous code cleaning

### DIFF
--- a/include/El/blas_like/level1/Copy.hpp
+++ b/include/El/blas_like/level1/Copy.hpp
@@ -128,21 +128,11 @@ void Copy( const Matrix<T,Device::GPU>& A, Matrix<T,Device::GPU>& B )
     const Int ldB = B.LDim();
     const T* ABuf = A.LockedBuffer();
     T* BBuf = B.Buffer();
-
-    cudaError_t error = cudaGetLastError();
-    if (error != cudaSuccess)
-        RuntimeError("Previously existing error!");
-
-    GPUManager* gpu_manager = GPUManager::getInstance();
-    error = cudaMemcpy2DAsync(BBuf, ldB*sizeof(T),
-                         ABuf, ldA*sizeof(T),
-                         height*sizeof(T), width,
-                         cudaMemcpyDeviceToDevice,
-                         gpu_manager->get_local_stream());
-
-    if (error != cudaSuccess)
-        RuntimeError("cudaMemcpy2DAsync error in Copy():\n\n",
-                     cudaGetErrorString(error));
+    EL_CHECK_CUDA(cudaMemcpy2DAsync(BBuf, ldB*sizeof(T),
+                                    ABuf, ldA*sizeof(T),
+                                    height*sizeof(T), width,
+                                    cudaMemcpyDeviceToDevice,
+                                    GPUManager::Stream()));
 }
 #endif // HYDROGEN_HAVE_CUDA
 

--- a/include/El/core/Matrix/impl_gpu.hpp
+++ b/include/El/core/Matrix/impl_gpu.hpp
@@ -351,56 +351,44 @@ template<typename Ring>
 Ring Matrix<Ring, Device::GPU>::Get(Int i, Int j) const
 {
     EL_DEBUG_CSE;
-
-    LogicError("DON'T DO SINGLE-ENTRY MANIPULATION ON WITH GPU MATRICES!");
-
     EL_DEBUG_ONLY(this->AssertValidEntry(i, j))
-        if (i == END) i = this->Height() - 1;
+    if (i == END) i = this->Height() - 1;
     if (j == END) j = this->Width() - 1;
-    return CRef(i, j);
+    Ring val = Ring(0);
+    EL_CHECK_CUDA(cudaMemcpy( &val, &data_[i+j*this->LDim()],
+                              sizeof(Ring), cudaMemcpyDeviceToHost ));
+    return val;
 }
 
 template<typename Ring>
 Base<Ring> Matrix<Ring, Device::GPU>::GetRealPart(Int i, Int j) const
 {
     EL_DEBUG_CSE;
-
-    LogicError("DON'T DO SINGLE-ENTRY MANIPULATION ON WITH GPU MATRICES!");
-
     EL_DEBUG_ONLY(this->AssertValidEntry(i, j))
-        if (i == END) i = this->Height() - 1;
-    if (j == END) j = this->Width() - 1;
-    return El::RealPart(CRef(i, j));
+    return El::RealPart(Get(i, j));
 }
 
 template<typename Ring>
 Base<Ring> Matrix<Ring, Device::GPU>::GetImagPart(Int i, Int j) const
 {
     EL_DEBUG_CSE;
-
-    LogicError("DON'T DO SINGLE-ENTRY MANIPULATION ON WITH GPU MATRICES!");
-
     EL_DEBUG_ONLY(this->AssertValidEntry(i, j))
-        if (i == END) i = this->Height() - 1;
-    if (j == END) j = this->Width() - 1;
-    return El::ImagPart(CRef(i, j));
+    return El::ImagPart(Get(i, j));
 }
 
 template<typename Ring>
 void Matrix<Ring, Device::GPU>::Set(Int i, Int j, Ring const& alpha)
 {
     EL_DEBUG_CSE;
-
-    LogicError("DON'T DO SINGLE-ENTRY MANIPULATION ON WITH GPU MATRICES!");
-
     EL_DEBUG_ONLY(
         this->AssertValidEntry(i, j);
         if (this->Locked())
             LogicError("Cannot modify data of locked matrices");
         )
-        if (i == END) i = this->Height() - 1;
+    if (i == END) i = this->Height() - 1;
     if (j == END) j = this->Width() - 1;
-    Ref(i, j) = alpha;
+    EL_CHECK_CUDA(cudaMemcpy( &data_[i+j*this->LDim()], &alpha,
+                              sizeof(Ring), cudaMemcpyHostToDevice ));
 }
 
 template<typename Ring>
@@ -414,17 +402,14 @@ Matrix<Ring, Device::GPU>::SetRealPart(
     Int i, Int j, Base<Ring> const& alpha)
 {
     EL_DEBUG_CSE;
-
-    LogicError("DON'T DO SINGLE-ENTRY MANIPULATION ON WITH GPU MATRICES!");
-
     EL_DEBUG_ONLY(
         this->AssertValidEntry(i, j);
         if (this->Locked())
             LogicError("Cannot modify data of locked matrices");
         )
-        if (i == END) i = this->Height() - 1;
-    if (j == END) j = this->Width() - 1;
-    El::SetRealPart(Ref(i, j), alpha);
+    Ring val = Get(i, j);
+    El::SetRealPart(val, alpha);
+    Set(i, j, val);
 }
 
 template<typename Ring>
@@ -437,17 +422,14 @@ void
 Matrix<Ring, Device::GPU>::SetImagPart(Int i, Int j, Base<Ring> const& alpha)
 {
     EL_DEBUG_CSE;
-
-    LogicError("DON'T DO SINGLE-ENTRY MANIPULATION ON WITH GPU MATRICES!");
-
     EL_DEBUG_ONLY(
         this->AssertValidEntry(i, j);
         if (this->Locked())
             LogicError("Cannot modify data of locked matrices");
         )
-        if (i == END) i = this->Height() - 1;
-    if (j == END) j = this->Width() - 1;
-    El::SetImagPart(Ref(i, j), alpha);
+    Ring val = Get(i, j);
+    El::SetImagPart(val, alpha);
+    Set(i, j, val);
 }
 
 template<typename Ring>
@@ -459,17 +441,14 @@ template<typename Ring>
 void Matrix<Ring, Device::GPU>::Update(Int i, Int j, Ring const& alpha)
 {
     EL_DEBUG_CSE;
-
-    LogicError("DON'T DO SINGLE-ENTRY MANIPULATION ON WITH GPU MATRICES!");
-
     EL_DEBUG_ONLY(
         this->AssertValidEntry(i, j);
         if (this->Locked())
             LogicError("Cannot modify data of locked matrices");
         )
-        if (i == END) i = this->Height() - 1;
-    if (j == END) j = this->Width() - 1;
-    Ref(i, j) += alpha;
+    Ring val = Get(i, j);
+    val += alpha;
+    Set(i, j, val);
 }
 
 template<typename Ring>
@@ -482,17 +461,14 @@ void
 Matrix<Ring, Device::GPU>::UpdateRealPart(Int i, Int j, Base<Ring> const& alpha)
 {
     EL_DEBUG_CSE;
-
-    LogicError("DON'T DO SINGLE-ENTRY MANIPULATION ON WITH GPU MATRICES!");
-
     EL_DEBUG_ONLY(
         this->AssertValidEntry(i, j);
         if (this->Locked())
             LogicError("Cannot modify data of locked matrices");
         )
-        if (i == END) i = this->Height() - 1;
-    if (j == END) j = this->Width() - 1;
-    El::UpdateRealPart(Ref(i, j), alpha);
+    Ring val = Get(i, j);
+    El::UpdateRealPart(val, alpha);
+    Set(i, j, val);
 }
 
 template<typename Ring>
@@ -505,17 +481,14 @@ void
 Matrix<Ring, Device::GPU>::UpdateImagPart(Int i, Int j, Base<Ring> const& alpha)
 {
     EL_DEBUG_CSE;
-
-    LogicError("DON'T DO SINGLE-ENTRY MANIPULATION ON WITH GPU MATRICES!");
-
     EL_DEBUG_ONLY(
         this->AssertValidEntry(i, j);
         if (this->Locked())
             LogicError("Cannot modify data of locked matrices");
         )
-        if (i == END) i = this->Height() - 1;
-    if (j == END) j = this->Width() - 1;
-    El::UpdateImagPart(Ref(i, j), alpha);
+    Ring val = Get(i, j);
+    El::UpdateImagPart(val, alpha);
+    Set(i, j, val);
 }
 
 template<typename Ring>
@@ -527,9 +500,6 @@ template<typename Ring>
 void Matrix<Ring, Device::GPU>::MakeReal(Int i, Int j)
 {
     EL_DEBUG_CSE;
-
-    LogicError("DON'T DO SINGLE-ENTRY MANIPULATION ON WITH GPU MATRICES!");
-
     EL_DEBUG_ONLY(
         this->AssertValidEntry(i, j);
         if (this->Locked())
@@ -542,9 +512,6 @@ template<typename Ring>
 void Matrix<Ring, Device::GPU>::Conjugate(Int i, Int j)
 {
     EL_DEBUG_CSE;
-
-    LogicError("DON'T DO SINGLE-ENTRY MANIPULATION ON WITH GPU MATRICES!");
-
     EL_DEBUG_ONLY(
         this->AssertValidEntry(i, j);
         if (this->Locked())
@@ -625,41 +592,32 @@ void Matrix<Ring, Device::GPU>::Control_
 // ===========================================================
 template<typename Ring>
 Ring const& Matrix<Ring, Device::GPU>::CRef(Int i, Int j) const
-    EL_NO_RELEASE_EXCEPT
 {
-    return data_[i+j*this->LDim()];
+    LogicError("Attempted to get reference to entry of a GPU matrix");
+    return data_[0];
 }
 
 template<typename Ring>
 Ring const& Matrix<Ring, Device::GPU>::operator()(Int i, Int j) const
 {
-    EL_DEBUG_CSE;
-
-    LogicError("DON'T DO SINGLE-ENTRY MANIPULATION ON WITH GPU MATRICES!");
-
-    EL_DEBUG_ONLY(this->AssertValidEntry(i, j))
-        return data_[i+j*this->LDim()];
+    LogicError("Attempted to get reference to entry of a GPU matrix");
+    return data_[0];
 }
 
 template<typename Ring>
 Ring& Matrix<Ring, Device::GPU>::Ref(Int i, Int j)
-    EL_NO_RELEASE_EXCEPT
 {
-    return data_[i+j*this->LDim()];
+    LogicError("Attempted to get reference to entry of a GPU matrix");
+    return data_[0];
 }
 
 template<typename Ring>
 Ring& Matrix<Ring, Device::GPU>::operator()(Int i, Int j)
 {
-    EL_DEBUG_CSE;
-    LogicError("DON'T DO SINGLE-ENTRY MANIPULATION ON WITH GPU MATRICES!");
-#ifndef EL_RELEASE
-    this->AssertValidEntry(i, j);
-    if (this->Locked())
-        LogicError("Cannot modify data of locked matrices");
-#endif // !EL_RELEASE
-    return data_[i+j*this->LDim()];
+    LogicError("Attempted to get reference to entry of a GPU matrix");
+    return data_[0];
 }
+
 #if 0
 // Assertions
 // ==========

--- a/include/El/core/Matrix/impl_gpu.hpp
+++ b/include/El/core/Matrix/impl_gpu.hpp
@@ -70,21 +70,13 @@ Matrix<Ring, Device::GPU>::Matrix(Matrix<Ring, Device::CPU> const& A)
     : Matrix{A.Height(), A.Width(), A.LDim()}
 {
     EL_DEBUG_CSE;
-    GPUManager* gpu_manager = GPUManager::getInstance();
-    auto error = cudaMemcpy2DAsync(data_, A.Width()*sizeof(Ring),
-                              A.LockedBuffer(), A.Width()*sizeof(Ring),
-                              A.Width()*sizeof(Ring), A.LDim(),
-                              //height_*sizeof(Ring),
-                              cudaMemcpyHostToDevice,
-                              gpu_manager->get_local_stream());
-    if (error != cudaSuccess)
-    {
-        std::ostringstream oss;
-        oss << "Error in copy to GPU: "
-            << cudaGetErrorName(error) << "\ndescription: "
-            << cudaGetErrorString(error) << "\n";
-        RuntimeError(oss.str());
-    }
+    auto stream = GPUManager::Stream();
+    EL_CHECK_CUDA(cudaMemcpy2DAsync(data_, this->LDim()*sizeof(Ring),
+                                    A.LockedBuffer(), A.LDim()*sizeof(Ring),
+                                    A.Height()*sizeof(Ring), A.Width(),
+                                    cudaMemcpyHostToDevice,
+                                    stream));
+    EL_CHECK_CUDA(cudaStreamSynchronize(stream));
 }
 
 template <typename Ring>

--- a/include/El/core/Memory/impl.hpp
+++ b/include/El/core/Memory/impl.hpp
@@ -105,10 +105,9 @@ struct MemHelper<G,Device::GPU>
 #ifdef HYDROGEN_HAVE_CUB
         case 1:
             {
-                GPUManager* gpu_manager = GPUManager::getInstance();
                 status = cubMemPool.DeviceAllocate(&ptr,
                                                    size * sizeof(G),
-                                                   gpu_manager->get_local_stream());
+                                                   GPUManager::Stream());
             }
             break;
 #endif // HYDROGEN_HAVE_CUB
@@ -150,16 +149,9 @@ struct MemHelper<G,Device::GPU>
 
     static void MemZero( G* buffer, size_t numEntries, unsigned int mode )
     {
-        GPUManager* gpu_manager = GPUManager::getInstance();
-        auto error = cudaMemsetAsync(buffer,
-                                     0,
-                                     numEntries * sizeof(G),
-                                     gpu_manager->get_local_stream());
-        if (error != cudaSuccess)
-        {
-            RuntimeError("cudaMemsetAsync failed with message: \"",
-                         cudaGetErrorString(error), "\"");
-        }
+        EL_CHECK_CUDA(cudaMemsetAsync(buffer, 0x0,
+                                      numEntries * sizeof(G),
+                                      GPUManager::Stream()));
     }
 
 };

--- a/include/El/core/imports/cuda.hpp
+++ b/include/El/core/imports/cuda.hpp
@@ -47,7 +47,7 @@ struct CudaError : std::runtime_error
         /* Call CUDA API routine, synchronizing before and after to */  \
         /* check for errors. */                                         \
         EL_CUDA_SYNC(true);                                             \
-        cudaError_t status_CHECK_CUDA = ( cuda_call );                  \
+        cudaError_t status_CHECK_CUDA = cuda_call ;                     \
         if( status_CHECK_CUDA != cudaSuccess ) {                        \
             cudaDeviceReset();                                          \
             throw CudaError(status_CHECK_CUDA,__FILE__,__LINE__,false); \
@@ -76,7 +76,7 @@ struct CudaError : std::runtime_error
     while (0)
 
 #ifdef EL_RELEASE
-#define EL_CHECK_CUDA( cuda_call ) ( cuda_call )
+#define EL_CHECK_CUDA( cuda_call ) cuda_call
 #define EL_CHECK_CUDA_KERNEL(kernel, Dg, Db, Ns, S, args) \
   EL_LAUNCH_CUDA_KERNEL(kernel, Dg, Db, Ns, S, args)
 #else
@@ -87,6 +87,8 @@ struct CudaError : std::runtime_error
 
 /** Initialize CUDA environment. */
 void InitializeCUDA(int,char*[]);
+/** Finalize CUDA environment. */
+void FinalizeCUDA();
 
 /** Singleton class to manage CUDA objects.
  *  This class also manages cuBLAS objects. Note that the CUDA device
@@ -101,8 +103,10 @@ public:
     GPUManager& operator=( const GPUManager& ) = delete;
     ~GPUManager();
 
-    /** Instantiate singleton instance of CUDA manager. */
-    static void Instantiate( int device = 0 );
+    /** Create new singleton instance of CUDA manager. */
+    static void Create( int device = 0 );
+    /** Destroy singleton instance of CUDA manager. */
+    static void Destroy();
     /** Get singleton instance of CUDA manager. */
     static GPUManager* Instance();
     /** Get number of visible CUDA devices. */

--- a/include/El/core/imports/cuda.hpp
+++ b/include/El/core/imports/cuda.hpp
@@ -89,16 +89,20 @@ struct CudaError : std::runtime_error
 void InitializeCUDA(int,char*[]);
 
 /** Singleton class to manage CUDA objects.
- *  This class also manages cuBLAS objects.
+ *  This class also manages cuBLAS objects. Note that the CUDA device
+ *  is set whenever the singleton instance is requested, i.e. in most
+ *  of the static functions.
  */
 class GPUManager
 {
 public:
 
-    GPUManager(const GPUManager&) = delete;
-    GPUManager& operator=(const GPUManager&) = delete;
+    GPUManager( const GPUManager& ) = delete;
+    GPUManager& operator=( const GPUManager& ) = delete;
     ~GPUManager();
 
+    /** Instantiate singleton instance of CUDA manager. */
+    static void Instantiate( int device = 0 );
     /** Get singleton instance of CUDA manager. */
     static GPUManager* Instance();
     /** Get number of visible CUDA devices. */
@@ -106,7 +110,7 @@ public:
     /** Get currently active CUDA device. */
     static int Device();
     /** Set active CUDA device. */
-    static void SetDevice(int device);
+    static void SetDevice( int device );
     /** Get CUDA stream. */
     static cudaStream_t Stream();
     /** Get cuBLAS handle. */
@@ -126,7 +130,7 @@ private:
     /** cuBLAS handle */
     cublasHandle_t cublasHandle_;
 
-    GPUManager();
+    GPUManager( int device = 0 );
 
 }; // class GPUManager
 

--- a/src/blas_like/level1/GPU/Axpy.cu
+++ b/src/blas_like/level1/GPU/Axpy.cu
@@ -1,6 +1,7 @@
 #include <El-lite.hpp>
 #include <El/blas_like/level1.hpp>
 #include <El/blas_like/level1/GPU/Axpy.hpp>
+#include <El/core/imports/cuda.hpp>
 
 namespace
 {
@@ -36,10 +37,12 @@ void Axpy_GPU_impl(
     const size_t size = height * width;
     const size_t blockDim = 256;
     const size_t gridDim = (size + blockDim - 1) / blockDim;
-    cudaStream_t stream = 0; // TODO: non-default stream
-    Axpy_kernel<T><<<gridDim, blockDim, 0, stream>>>(
-        height, width, alpha,
-        X, colStrideX, rowStrideX, Y, colStrideY, rowStrideY );
+    cudaStream_t stream = GPUManager::Stream();
+    EL_CHECK_CUDA_KERNEL( Axpy_kernel<T>,
+                          gridDim, blockDim, 0, stream,
+                          ( height, width, alpha,
+                            X, colStrideX, rowStrideX,
+                            Y, colStrideY, rowStrideY ) );
 }
 
 template void Axpy_GPU_impl(

--- a/src/blas_like/level1/GPU/Copy.cu
+++ b/src/blas_like/level1/GPU/Copy.cu
@@ -1,6 +1,7 @@
 #include <El-lite.hpp>
 #include <El/blas_like/level1.hpp>
 #include <El/blas_like/level1/GPU/Copy.hpp>
+#include <El/core/imports/cuda.hpp>
 
 namespace
 {
@@ -34,10 +35,12 @@ void Copy_GPU_impl(
     const size_t size = height * width;
     const size_t blockDim = 256;
     const size_t gridDim = (size + blockDim - 1) / blockDim;
-    cudaStream_t stream = 0; // TODO: non-default stream
-    Copy_kernel<T><<<gridDim, blockDim, 0, stream>>>(
-        height, width,
-        X, colStrideX, rowStrideX, Y, colStrideY, rowStrideY );
+    cudaStream_t stream = GPUManager::Stream();
+    EL_CHECK_CUDA_KERNEL( Copy_kernel<T>,
+                          gridDim, blockDim, 0, stream,
+                          ( height, width,
+                            X, colStrideX, rowStrideX,
+                            Y, colStrideY, rowStrideY ) );
 }
 
 template void Copy_GPU_impl(

--- a/src/core/environment.cpp
+++ b/src/core/environment.cpp
@@ -240,6 +240,10 @@ void Finalize()
         FinalizeRandom();
     }
 
+#ifdef HYDROGEN_HAVE_CUDA
+    FinalizeCUDA();
+#endif
+
     EL_DEBUG_ONLY( CloseLog() )
 #ifdef HYDROGEN_HAVE_MPC
     if( EL_RUNNING_ON_VALGRIND )

--- a/src/core/imports/CMakeLists.txt
+++ b/src/core/imports/CMakeLists.txt
@@ -14,7 +14,7 @@ set_full_path(THIS_DIR_SOURCES
   )
 
 if (HYDROGEN_HAVE_CUDA)
-  set_full_path(CUDA_SOURCES cublas.cpp)
+  set_full_path(CUDA_SOURCES cuda.cpp cublas.cpp)
   list(APPEND THIS_DIR_SOURCES ${CUDA_SOURCES})
 endif()
 

--- a/src/core/imports/cuda.cpp
+++ b/src/core/imports/cuda.cpp
@@ -1,0 +1,157 @@
+#include "El-lite.hpp"
+#include "El/core/imports/cuda.hpp"
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <cublas_v2.h>
+
+namespace El
+{
+
+// Global static pointer used to ensure a single instance of the GPUManager class.
+std::unique_ptr<GPUManager> GPUManager::instance_ = nullptr;
+
+void InitializeCUDA( int argc, char* argv[] )
+{
+
+    // Instantiate CUDA manager
+    GPUManager::Instance();
+
+    // Choose device by parsing command-line arguments
+    const int numDevices = GPUManager::NumDevices();
+    int device = -1;
+    cudaDeviceProp deviceProp;
+    // if( argc > 0 ) { device = atoi(argv[0]); }
+
+    // Choose device by parsing environment variables
+    if( device < 0 )
+    {
+        char *env = nullptr;
+        if( env == nullptr ) { env = getenv("SLURM_LOCALID"); }
+        if( env == nullptr ) { env = getenv("MV2_COMM_WORLD_LOCAL_RANK"); }
+        if( env == nullptr ) { env = getenv("OMPI_COMM_WORLD_LOCAL_RANK"); }
+        if( env != nullptr )
+        {
+
+            // Allocate devices amongst ranks in round-robin fashion
+            const int localRank = atoi(env);
+            device = localRank % numDevices;
+
+            // If device is shared amongst MPI ranks, check its
+            // compute mode
+            if( localRank >= numDevices )
+            {
+                EL_FORCE_CHECK_CUDA( cudaGetDeviceProperties( &deviceProp,
+                                                              device ) );
+                switch( deviceProp.computeMode )
+                {
+                case cudaComputeModeExclusive:
+                    cudaDeviceReset();
+                    RuntimeError("Attempted to share CUDA device ",device,
+                                 " amongst multiple MPI ranks, ",
+                                 "but it is set to cudaComputeModeExclusive");
+                    break;
+                case cudaComputeModeExclusiveProcess:
+                    cudaDeviceReset();
+                    RuntimeError("Attempted to share CUDA device ",device,
+                                 " amongst multiple MPI ranks, ",
+                                 "but it is set to cudaComputeModeExclusiveProcess");
+                    break;
+                }
+            }
+
+        }
+    }
+
+    // Set CUDA device
+    if( device < 0 ) { device = 0; }
+    GPUManager::SetDevice(device);
+
+    // Check device compute mode
+    EL_FORCE_CHECK_CUDA(cudaGetDeviceProperties(&deviceProp, device));
+    if( deviceProp.computeMode == cudaComputeModeProhibited )
+    {
+        cudaDeviceReset();
+        RuntimeError("CUDA Device ",device," is set with ComputeModeProhibited");
+    }
+
+}
+
+GPUManager::GPUManager()
+    : numDevices_{0}, device_{0}, stream_{0}, cublasHandle_{nullptr}
+{
+
+    // Make sure there are CUDA devices available
+    EL_FORCE_CHECK_CUDA( cudaGetDeviceCount( &numDevices_ ) );
+    if( numDevices_ < 1 )
+    {
+        RuntimeError("No CUDA devices found!");
+    }
+
+    // Initialize CUDA objects
+    EL_CHECK_CUDA( cudaSetDevice( device_ ) );
+    EL_CHECK_CUDA( cudaStreamCreate( &stream_ ) );
+    
+    // Initialize cuBLAS
+    EL_FORCE_CHECK_CUBLAS( cublasCreate( &cublasHandle_ ) );
+    EL_CHECK_CUBLAS( cublasSetStream( cublasHandle_, stream_ ) );
+    EL_CHECK_CUBLAS( cublasSetPointerMode( cublasHandle_,
+                                           CUBLAS_POINTER_MODE_HOST ) );
+
+}
+
+GPUManager::~GPUManager()
+{
+    if( cublasHandle_ != nullptr )
+    {
+        EL_CHECK_CUBLAS( cublasDestroy( cublasHandle_ ) );
+    }
+    if( stream_ != 0 )
+    {
+        EL_CHECK_CUDA( cudaStreamDestroy( stream_ ) );
+    }
+}
+
+GPUManager* GPUManager::Instance()
+{
+    if( !instance_ )
+    {
+        instance_.reset( new GPUManager() );
+    }
+    EL_CHECK_CUDA( cudaSetDevice( instance_->device_ ) );
+    return instance_.get();
+}
+
+int GPUManager::NumDevices()
+{ return Instance()->numDevices_; }
+
+int GPUManager::Device()
+{ return Instance()->device_; }
+
+void GPUManager::SetDevice( int device )
+{
+    auto* instance = Instance();
+    if( device < 0 || device >= instance->numDevices_ )
+    {
+      RuntimeError("Attempted to set invalid CUDA device ",
+                   "(requested device ",device,", ",
+                   "but there are ",instance->numDevices_," devices)");
+    }
+    instance->device_ = device;
+    EL_CHECK_CUDA( cudaSetDevice( instance->device_ ) );
+}
+
+cudaStream_t GPUManager::Stream()
+{ return Instance()->stream_; }
+
+cublasHandle_t GPUManager::cuBLASHandle()
+{
+    auto* instance = Instance();
+    auto handle = instance->cublasHandle_;
+    EL_CHECK_CUBLAS( cublasSetStream( handle, instance->stream_ ) );
+    EL_CHECK_CUBLAS( cublasSetPointerMode( handle,
+                                           CUBLAS_POINTER_MODE_HOST ) );
+    return handle;
+}
+
+} // namespace El


### PR DESCRIPTION
Changes:
- Custom CUDA kernels now use streams from GPU manager rather than default stream.
- Added static functions to GPUManager class for convenience.
- Made code style in GPUManager consistent with rest of Elemental.
- Made dedicated source file for GPU manager and CUDA initialization.
- Fixed GPU-CPU memory transfer bugs in Matrix copy constructors.
- Added error checking macro for CUDA kernels.
- Expanded usage of CUDA error checking macro.
- Destroy and create new CUDA objects whenever the device is changed.
- Synchronize GPU before and after each MPI call.
- Single-entry manipulation functions for GPU matrices.