### PR TITLE
Bugfixes when GPUs are in exclusive compute mode.

### DIFF
--- a/src/core/imports/cuda.cpp
+++ b/src/core/imports/cuda.cpp
@@ -63,19 +63,14 @@ void InitializeCUDA( int argc, char* argv[] )
     }
 
     // Check device compute mode
-    if( device >= 0 )
-    {
-        EL_FORCE_CHECK_CUDA(cudaGetDeviceProperties(&deviceProp, device));
-    }
-    else
-    {
-        EL_FORCE_CHECK_CUDA(cudaGetDeviceProperties(&deviceProp, 0));
-    }
+    if( device < 0 ) { device = 0; }
+    EL_FORCE_CHECK_CUDA(cudaGetDeviceProperties(&deviceProp, device));
     switch( deviceProp.computeMode )
     {
     case cudaComputeModeExclusive:
     case cudaComputeModeExclusiveProcess:
-        device = -1; // Let CUDA handle GPU assignments
+        // Let CUDA handle GPU assignments
+        EL_FORCE_CHECK_CUDA(cudaGetDevice( &device ));
         break;
     case cudaComputeModeProhibited:
         cudaDeviceReset();
@@ -97,7 +92,7 @@ GPUManager::GPUManager(int device)
 
     // Check if device is valid
     EL_FORCE_CHECK_CUDA( cudaGetDeviceCount( &numDevices_ ) );
-    if( device_ >= numDevices_ )
+    if( device_ < 0 || device_ >= numDevices_ )
     {
         RuntimeError("Attempted to set invalid CUDA device ",
                      "(requested device ",device_,", ",
@@ -105,10 +100,7 @@ GPUManager::GPUManager(int device)
     }
 
     // Initialize CUDA and cuBLAS objects
-    if( device_ >= 0 )
-    {
-        EL_FORCE_CHECK_CUDA( cudaSetDevice( device_ ) );
-    }
+    EL_FORCE_CHECK_CUDA( cudaSetDevice( device_ ) );
     EL_FORCE_CHECK_CUDA( cudaStreamCreate( &stream_ ) );
     EL_FORCE_CHECK_CUBLAS( cublasCreate( &cublasHandle_ ) );
     EL_FORCE_CHECK_CUBLAS( cublasSetStream( cublasHandle_, stream_ ) );
@@ -119,10 +111,7 @@ GPUManager::GPUManager(int device)
 
 GPUManager::~GPUManager()
 {
-    if( device_ >= 0 )
-    {
-        EL_FORCE_CHECK_CUDA( cudaSetDevice( device_ ) );
-    }
+    EL_FORCE_CHECK_CUDA( cudaSetDevice( device_ ) );
     if( cublasHandle_ != nullptr )
     {
         EL_FORCE_CHECK_CUBLAS( cublasDestroy( cublasHandle_ ) );
@@ -142,10 +131,7 @@ void GPUManager::Destroy()
 GPUManager* GPUManager::Instance()
 {
     if( !instance_ ) { Create(); }
-    if( instance_->device_ >= 0 )
-    {
-        EL_CHECK_CUDA( cudaSetDevice( instance_->device_ ) );
-    }
+    EL_CHECK_CUDA( cudaSetDevice( instance_->device_ ) );
     return instance_.get();
 }
 

--- a/src/core/imports/cuda.cpp
+++ b/src/core/imports/cuda.cpp
@@ -20,20 +20,20 @@ void InitializeCUDA( int argc, char* argv[] )
     cudaDeviceProp deviceProp;
 
     // Choose device by parsing command-line arguments
-    // if( argc > 0 ) { device = atoi(argv[0]); }
+    // if( argc > 0 ) { device = std::atoi(argv[0]); }
 
     // Choose device by parsing environment variables
     if( device < 0 )
     {
-        char *env = nullptr;
-        if( env == nullptr ) { env = getenv("SLURM_LOCALID"); }
-        if( env == nullptr ) { env = getenv("MV2_COMM_WORLD_LOCAL_RANK"); }
-        if( env == nullptr ) { env = getenv("OMPI_COMM_WORLD_LOCAL_RANK"); }
-        if( env != nullptr )
+        std::string env;
+        if( env.empty() ) { env = std::getenv("SLURM_LOCALID"); }
+        if( env.empty() ) { env = std::getenv("MV2_COMM_WORLD_LOCAL_RANK"); }
+        if( env.empty() ) { env = std::getenv("OMPI_COMM_WORLD_LOCAL_RANK"); }
+        if( env.empty() )
         {
 
             // Allocate devices amongst ranks in round-robin fashion
-            const int localRank = atoi(env);
+            const int localRank = std::atoi(env.c_str());
             device = localRank % numDevices;
 
             // If device is shared amongst MPI ranks, check its


### PR DESCRIPTION
If the GPUs are in exclusive compute mode, we use CUDA's GPU allocation scheme rather than our round-robin approach. It's not ideal, but I don't see a nicer way.