### PR TITLE
Function to instantiate a distributed matrix.

### DIFF
--- a/include/El/core/DistMatrix/Abstract.hpp
+++ b/include/El/core/DistMatrix/Abstract.hpp
@@ -295,6 +295,15 @@ public:
 
     virtual Device GetLocalDevice() const EL_NO_EXCEPT = 0;
 
+    // Static functions
+    // ================
+
+    // Instantiate with runtime template arguments
+    static type* Instantiate
+    (const El::Grid& grid=Grid::Default(), int root=0,
+     Dist colDist=MC, Dist rowDist=MR, DistWrap wrap=ELEMENT,
+     Device dev=Device::CPU);
+  
 private:
     // Member variables
     // ================


### PR DESCRIPTION
This PR implements an `Instantiate()` function that allows the user to specify template parameters for the DistMatrix constructor at runtime. I'm not sure about best place to put it, so for now it's a static function of `AbstractDistMatrix<T>`.